### PR TITLE
refactor(spx-gui):decouple draw_line module

### DIFF
--- a/spx-gui/src/components/editor/common/painter/components/draw_line.vue
+++ b/spx-gui/src/components/editor/common/painter/components/draw_line.vue
@@ -31,12 +31,12 @@ interface Props {
 
 const props = defineProps<Props>()
 
-// Emits
-interface Emits {
-  (e: 'line-created', line: paper.Path): void
-}
+// // Emits
+// interface Emits {
+//   (e: 'line-created', line: string): void
+// }
 
-const emit = defineEmits<Emits>()
+// const emit = defineEmits<Emits>()
 
 // 接口定义
 interface Point {
@@ -48,6 +48,15 @@ interface Point {
 const isDrawing = ref<boolean>(false)
 const startPoint = ref<Point | null>(null)
 const previewPoint = ref<Point>({ x: 0, y: 0 })
+
+//注入父组件接口
+import { inject, type Ref } from 'vue'  
+
+const getAllPathsValue = inject<() => paper.Path[]>('getAllPathsValue')!
+const setAllPathsValue = inject<(paths: paper.Path[]) => void>('setAllPathsValue')!
+const exportSvgAndEmit = inject<() => void>('exportSvgAndEmit')!
+
+
 
 // 创建直线路径
 const createLine = (start: Point, end: Point): paper.Path => {
@@ -89,8 +98,10 @@ const handleCanvasClick = (point: Point): void => {
   } else {
     // 完成画线
     const line = createLine(startPoint.value!, point)
-    emit('line-created', line)
-    
+    const currentPaths = getAllPathsValue()
+    currentPaths.push(line)
+    setAllPathsValue(currentPaths)
+    exportSvgAndEmit()
     // 重置状态
     resetDrawing()
   }

--- a/spx-gui/src/components/editor/common/painter/painter.vue
+++ b/spx-gui/src/components/editor/common/painter/painter.vue
@@ -153,7 +153,6 @@
         :canvas-width="canvasWidth"
         :canvas-height="canvasHeight"
         :is-active="currentTool === 'line'"
-        @line-created="handleLineCreated"
       />
       
       <!-- 笔刷绘制组件 -->
@@ -379,11 +378,11 @@ const selectTool = (tool: ToolType): void => {
 
 // 处理直线创建
 //todo:逻辑迁移到draw_line组件内部
-const handleLineCreated = (line: paper.Path): void => {
-  allPaths.value.push(line)
-  paper.view.update()
-  exportSvgAndEmit()
-}
+// const handleLineCreated = (line: paper.Path): void => {
+//   allPaths.value.push(line)
+//   paper.view.update()
+//   exportSvgAndEmit()
+// }
 
 
 //painter提供allPath接口给直线组件
@@ -709,6 +708,7 @@ const { exportSvgAndEmit } = useSvgExporter({
 
 provide('currentTool', currentTool)
 provide('reshapeRef', reshapeRef)
+provide('backgroundRect', backgroundRect)
 provide('isImportingFromProps', isImportingFromProps)
 provide('exportSvgAndEmit', exportSvgAndEmit)
 


### PR DESCRIPTION
Decoupling: The line-drawing component is now fully decoupled from the painter. All logic and data interaction for the line-drawing process are now handled internally by the draw_line component, only delegation is still processed inside painter
Resolve #38 